### PR TITLE
Fix code scanning alert no. 4: Multiplication result converted to larger type

### DIFF
--- a/desync.c
+++ b/desync.c
@@ -469,7 +469,7 @@ ssize_t desync(int sfd, char *buffer, size_t bfsize,
             pos += gen_offset(part.pos, 
                 part.flag, n - pos - 5, lp, type, host_pos - 5, len);
             
-            pos += part.s * (part.r - r);
+            pos += (long)part.s * (part.r - r);
             if (pos < lp) {
                 LOG(LOG_E, "tlsrec cancel: %ld < %ld\n", pos, lp);
                 break;


### PR DESCRIPTION
Fixes [https://github.com/SashaXser/byedpi/security/code-scanning/4](https://github.com/SashaXser/byedpi/security/code-scanning/4)

To fix the problem, we need to ensure that the multiplication is performed using the larger integer type (`long`) to avoid overflow. This can be achieved by casting one of the operands to `long` before performing the multiplication. Specifically, we can cast `part.s` to `long` before multiplying it with `(part.r - r)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
