### PR TITLE
Fix code scanning alert no. 5: Multiplication result converted to larger type

### DIFF
--- a/desync.c
+++ b/desync.c
@@ -501,7 +501,7 @@ ssize_t desync(int sfd, char *buffer, size_t bfsize,
         long pos = gen_offset(part.pos,
             part.flag, n, lp, type, host_pos, len);
             
-        pos += part.s * (part.r - r);
+        pos += (long)part.s * (part.r - r);
         
         if (!(part.flag & OFFSET_START) && offset && pos <= offset) {
             LOG(LOG_S, "offset: %zd, skip\n", offset);


### PR DESCRIPTION
Fixes [https://github.com/SashaXser/byedpi/security/code-scanning/5](https://github.com/SashaXser/byedpi/security/code-scanning/5)

To fix the problem, we need to ensure that the multiplication is performed using the larger integer type (`long`) to avoid overflow. This can be done by casting one of the operands to `long` before performing the multiplication. Specifically, we can cast `part.s` to `long` before multiplying it with `(part.r - r)`.

- Change the multiplication `part.s * (part.r - r)` to `(long)part.s * (part.r - r)` to ensure the multiplication is done using `long`.
- This change should be made on line 504 in the file `desync.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
